### PR TITLE
Fix lost code in `node_modules/`

### DIFF
--- a/node_modules/nodebb-plugin-composer-default/static/lib/composer.js
+++ b/node_modules/nodebb-plugin-composer-default/static/lib/composer.js
@@ -652,9 +652,8 @@ define('composer', [
 		var titleEl = postContainer.find('.title');
 		var bodyEl = postContainer.find('textarea');
 		var thumbEl = postContainer.find('input#topic-thumb-url');
-		var onComposeRoute = postData.hasOwnProperty('template') && postData.template.compose === true;
 		var annonymousTypeEl = postContainer.find('#anonymousDropdown');
-
+		var onComposeRoute = postData.hasOwnProperty('template') && postData.template.compose === true;
 		const submitBtn = postContainer.find('.composer-submit');
 
 		titleEl.val(titleEl.val().trim());
@@ -722,7 +721,6 @@ define('composer', [
 				tags: tags.getTags(post_uuid),
 				timestamp: scheduler.getTimestamp(),
 				annonymousType: annonymousTypeEl.val(),
-
 			};
 		} else if (action === 'posts.reply') {
 			route = `/topics/${postData.tid}`;

--- a/node_modules/nodebb-plugin-composer-default/static/templates/partials/composer-title-container.tpl
+++ b/node_modules/nodebb-plugin-composer-default/static/templates/partials/composer-title-container.tpl
@@ -26,6 +26,14 @@
 	<div class="{{{ if !template.compose }}}d-none d-md-flex{{{ else }}}d-flex{{{ end }}} action-bar gap-1 align-items-center">
 		<button class="btn btn-sm btn-link text-body fw-semibold composer-minimize" data-action="hide"><i class="fa fa-angle-down"></i> <span class="d-none d-md-inline">[[topic:composer.hide]]</span></button>
 		<button class="btn btn-sm btn-link composer-discard text-body fw-semibold" data-action="discard"><i class="fa fa-trash"></i> <span class="d-none d-md-inline">[[topic:composer.discard]]</button>
+		<div class="form-group">
+            <label for="anonymousDropdown">[[topic:composer.select-anonymous-type]]</label>
+            <select class="form-control" id="anonymousDropdown" name="anonymousType">
+                <option value="none">[[topic:composer-anonymous-none]]</option>
+                <option value="student">[[topic:composer-anonymous-student]]</option>
+                <option value="all">[[topic:composer-anonymous-all]]</option>
+            </select>
+        </div>
 		<div class="btn-group btn-group-sm" component="composer/submit/container">
 			<button class="btn btn-primary composer-submit fw-bold {{{ if !(submitOptions.length || canSchedule) }}}rounded-1{{{ end }}}" data-action="post" data-text-variant=" [[topic:composer.schedule]]"><i class="fa fa-check"></i> <span class="d-none d-md-inline">[[topic:composer.submit]]</span></button>
 			<div component="composer/submit/options/container" data-submit-options="{submitOptions.length}" class="btn-group btn-group-sm {{{ if !(submitOptions.length || canSchedule) }}}hidden{{{ end }}}">

--- a/node_modules/nodebb-theme-harmony/templates/partials/topic/post.tpl
+++ b/node_modules/nodebb-theme-harmony/templates/partials/topic/post.tpl
@@ -7,15 +7,15 @@
 {{{ end }}}
 <div class="d-flex align-items-start gap-3">
 	<div class="bg-body d-none d-sm-block rounded-circle" style="outline: 2px solid var(--bs-body-bg);">
-	{{{ if (posts.annonymousType == "None") }}}
-		<a class="d-inline-block position-relative text-decoration-none" href="{{{ if ./user.userslug }}}{config.relative_path}/user/{./user.userslug}{{{ else }}}#{{{ end }}}" aria-label="[[aria:user-avatar-for, {./user.username}]]">
-			{buildAvatar(posts.user, "48px", true, "", "user/picture")}
-			<span component="user/status" class="position-absolute translate-middle-y border border-white border-2 rounded-circle status {posts.user.status}"><span class="visually-hidden">[[global:{posts.user.status}]]</span></span>
-		</a>
+		{{{ if (posts.annonymousType == "none") }}}
+			<a class="d-inline-block position-relative text-decoration-none" href="{{{ if ./user.userslug }}}{config.relative_path}/user/{./user.userslug}{{{ else }}}#{{{ end }}}" aria-label="[[aria:user-avatar-for, {./user.username}]]">
+				{buildAvatar(posts.user, "48px", true, "", "user/picture")}
+				<span component="user/status" class="position-absolute translate-middle-y border border-white border-2 rounded-circle status {posts.user.status}"><span class="visually-hidden">[[global:{posts.user.status}]]</span></span>
+			</a>
 		{{{ else }}}
-			<a class="d-inline-block position-relative text-decoration-none" href="" aria-label="[[aria:user-av
+			<a class="d-inline-block position-relative text-decoration-none" href="" aria-label="[[aria:user-avatar-for, Annonymous]]">
 				{buildAvatar(false, "48px", true, "", "")}
-				<span component="user/status" class="position-absolute translate-middle-y border border-white bord
+				<span component="user/status" class="position-absolute translate-middle-y border border-white border-2 rounded-circle status"><span class="visually-hidden"></span></span>
 			</a>
 		{{{ end }}}
 	</div>
@@ -30,25 +30,29 @@
 					<span component="user/status" class="position-absolute translate-middle-y border border-white border-2 rounded-circle status {posts.user.status}"><span class="visually-hidden">[[global:{posts.user.status}]]</span></span>
 				</a>
 			</div>
-			<a class="fw-bold text-nowrap" href="{{{ if ./user.userslug }}}{config.relative_path}/user/{./user.userslug}{{{ else }}}#{{{ end }}}" data-username="{posts.user.username}" data-uid="{posts.user.uid}">{posts.user.displayname}</a>
+
+			{{{ if (posts.annonymousType == "none") }}}
+				<a class="fw-bold text-nowrap" href="{{{ if ./user.userslug }}}{config.relative_path}/user/{./user.userslug}{{{ else }}}#{{{ end }}}" data-username="{posts.user.username}" data-uid="{posts.user.uid}">{posts.user.displayname}</a>
+			{{{ else }}}
+				<a class="fw-bold text-nowrap" href="" data-username="Annonymous-{posts.annonymousType}" data-uid="">Annonymous Person</a>
+			{{{ end }}}
 			{{{ each posts.user.selectedGroups }}}
 			{{{ if posts.user.selectedGroups.slug }}}
 			<!-- IMPORT partials/groups/badge.tpl -->
 			{{{ end }}}
 			{{{ end }}}
+
 			{{{ if posts.user.banned }}}
 			<span class="badge bg-danger rounded-1">[[user:banned]]</span>
 			{{{ end }}}
-			{{{ if (posts.annonymousType == "None") }}}
-				<a class="fw-bold text-nowrap" href="{{{ if ./user.userslug }}}{config.relative_path}/user/{./user
-			{{{ else }}}
-				<a class="fw-bold text-nowrap" href="" data-username="Annonymous-{posts.annonymousType}" data-uid=
-				{{{ end }}}
+
 			<div class="d-flex gap-1 align-items-center">
 				<span class="text-muted">{generateWroteReplied(@value, config.timeagoCutoff)}</span>
+
 				<i component="post/edit-indicator" class="fa fa-edit text-muted{{{ if privileges.posts:history }}} pointer{{{ end }}} edit-icon {{{ if !posts.editor.username }}}hidden{{{ end }}}" title="[[global:edited-timestamp, {isoTimeToLocaleString(./editedISO, config.userLang)}]]"></i>
 				<span data-editor="{posts.editor.userslug}" component="post/editor" class="visually-hidden">[[global:last-edited-by, {posts.editor.username}]] <span class="timeago" title="{isoTimeToLocaleString(posts.editedISO, config.userLang)}"></span></span>
 			</div>
+
 			{{{ if posts.user.custom_profile_info.length }}}
 			<div>
 				<span>
@@ -66,6 +70,7 @@
 		</div>
 
 		<div class="content mt-2 text-break" component="post/content" itemprop="text">
+			<p> this post is of {posts.annonymousType} type.</p>
 			{posts.content}
 		</div>
 	</div>


### PR DESCRIPTION
This PR adds the lost improvements to the composer plugin and UI/UX design from sprint 1.

Key Changes:
- Extract the `annonymousType` variable in  `compose.js` to send to the server. **(Composer Plugin)**
- Add conditionals for whether to display the user information (avatar and name) in case of certain `annonymousType` value. **(UX)**
- Add a dropdown menu for selecting the `annonymousType` value while creating the post. **(UX)**